### PR TITLE
enabled possiblity to specify the checkout for any given dependency.

### DIFF
--- a/tools/wurf_dependency_bundle.py
+++ b/tools/wurf_dependency_bundle.py
@@ -63,7 +63,7 @@ def add_dependency(opt, resolver):
         if type(resolver) != type(dependencies[name]) or \
            dependencies[name] != resolver:
             raise Errors.WafError('Incompatible dependency added %r <=> %r '
-                                  % (resolver, dependencies[name])) 
+                                  % (resolver, dependencies[name]))
     else:
         dependencies[name] = resolver
 
@@ -80,7 +80,6 @@ def expand_path(path):
     :return: the expanded path
     """
     return os.path.abspath(os.path.expanduser(path))
-
 
 def options(opt):
     """
@@ -166,8 +165,6 @@ def configure(conf):
         conf.env['BUNDLE_DEPENDENCIES'][name] = dependency_path
         conf.end_msg(dependency_path)
 
-
-
 def expand_bundle(conf, arg):
     """
     Expands the bundle arg so that e.g. 'ALL,-gtest' becomes the
@@ -211,7 +208,6 @@ def expand_bundle(conf, arg):
     candidates = [name for name in candidate_score if candidate_score[name] > 0]
     return candidates
 
-
 def explicit_dependencies(options):
     """
     Extracts the names of the dependencies where an explicit
@@ -229,7 +225,6 @@ def explicit_dependencies(options):
 
     return explicit_list
 
-
 @conf
 def has_dependency_path(self, name):
     """
@@ -241,7 +236,6 @@ def has_dependency_path(self, name):
 
     return False
 
-
 @conf
 def dependency_path(self, name):
     """
@@ -249,18 +243,9 @@ def dependency_path(self, name):
     """
     return self.env['BUNDLE_DEPENDENCIES'][name]
 
-
 @conf
 def is_toplevel(self):
     """
     :return: true if the current script is the top-level wscript otherwise false
     """
     return self.srcnode == self.path
-
-
-
-
-
-
-
-

--- a/tools/wurf_dependency_resolve.py
+++ b/tools/wurf_dependency_resolve.py
@@ -32,7 +32,6 @@ def options(opt):
         help="Use a specific git protocol to download dependencies. "
              "Supported protocols: {}".format(git_protocols))
 
-
 def configure(conf):
     """
     The configure function for the dependency resolver tool
@@ -74,7 +73,6 @@ def configure(conf):
     if git_protocol_handler not in git_protocols:
         conf.fatal('Unknown git protocol specified: {}, supported protocols '
                   ' are {}'.format(git_protocol_handler, git_protocols))
-
 
 class ResolveGitMajorVersion(object):
     """
@@ -167,7 +165,7 @@ class ResolveGitMajorVersion(object):
             ctx.git_submodule_update(cwd = master_path)
 
         # Do we need a specific checkout? (master, commit or dev branch)
-        
+
         if use_checkout:
             checkout_path = os.path.join(repo_folder, use_checkout)
             # The master is already up-to-date, but the other checkouts
@@ -291,8 +289,6 @@ class ResolveGitMajorVersion(object):
 
         return f % (self.name, self.git_repository, self.major_version)
 
-
-
 ##class ResolveGitFollowMaster(object):
 ##    """
 ##    Follow the master branch
@@ -347,13 +343,3 @@ class ResolveGitMajorVersion(object):
 ##        f = 'ResolveGitFollowMaster(name=%s, git_repository=%s)'
 ##
 ##        return f % (self.name, self.git_repository)
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
@petya2164, @mortenvp. We can now checkout the master, commit id, or brach of any dependency. This will enable the master branch of the repositories to always be releasable.

The option is specified from the commandline as follows:

./waf configure --bundle=ALL --bundle-path=../dependencies --fifi-use-checkout=boost_to_std
