### PR TITLE
Extend dependency resolver

### DIFF
--- a/test/python/test_dependency_resolve.py
+++ b/test/python/test_dependency_resolve.py
@@ -5,7 +5,7 @@ sys.path.append('../../tools')
 sys.path.append('../../python-semver')
 
 import unittest
-import dependency_resolve as dr
+import wurf_dependency_resolve as dr
 import mock
 import os
 
@@ -13,58 +13,74 @@ import os
 class TestResolveGitMajorVersion(unittest.TestCase):
 
     def test_select_tag(self):
-        tags = ['2.3.4', '1.0.0', '1.3.5', '1.0.1', '2.0.0', '1.1.2']
+        tags = ['2.3.4', '1.0.0', '1.3.5', '1.0.1', '2.0.0', '1.1.2', '1.1.1']
 
         # Major version 1
-        resolver = dr.ResolveGitMajorVersion(name="test",
-                                             git_repository="git://dummy.git",
-                                             major_version=1)
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=1)
 
         tag = resolver.select_tag(tags)
         self.assertEqual(tag, '1.3.5')
 
         # Major version 2
-        resolver = dr.ResolveGitMajorVersion(name="test",
-                                             git_repository="git://dummy.git",
-                                             major_version=2)
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=2)
+
+        tag = resolver.select_tag(tags)
+        self.assertEqual(tag, '2.3.4')
+
+        # Major minor version 1
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=1,
+                                     minor=1)
+
+        tag = resolver.select_tag(tags)
+        self.assertEqual(tag, '1.1.2')
+
+        # Major minor patch version 1
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=1,
+                                     minor=1,
+                                     patch=1)
+
+        tag = resolver.select_tag(tags)
+        self.assertEqual(tag, '1.1.1')
+
+        # Major version 2
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=2)
 
         tag = resolver.select_tag(tags)
         self.assertEqual(tag, '2.3.4')
 
     def test_resolve(self):
-        resolver = dr.ResolveGitMajorVersion(name="test",
-                                             git_repository="git://dummy.git",
-                                             major_version=1)
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=1)
 
         m = mock.Mock()
         m.git_tags = mock.Mock(return_value=['1.0.0', '1.2.3', '1.2.0'])
-
         repo_dir = os.path.abspath(os.path.expanduser('~/here'))
 
-        resolver.resolve(m, repo_dir)
+        resolver.resolve(
+            ctx=m,
+            path=repo_dir,
+            use_checkout=None,
+            protocol_handler='git://')
 
         # Check function calls
         self.assertEqual(m.method_calls[0], (
-            'git_clone', ('git://dummy.git', repo_dir + '/test-master'),
-            {'cwd': repo_dir}))
+            'git_clone', ('git://dummy.git', repo_dir + '/test-9199d9/master'),
+            {'cwd': repo_dir + '/test-9199d9'}))
 
-        self.assertEqual(m.method_calls[1], (
-            'git_pull', (),
-            {'cwd': repo_dir + '/test-master'}))
-
-        # We don't see the call to git_tags() here since we mocked it
-        # out above
-
-        self.assertEqual(m.method_calls[2], (
-            'git_local_clone', (repo_dir + '/test-master',
-                                repo_dir + '/test-1.2.3'),
-            {'cwd': repo_dir}))
-
-        self.assertEqual(m.method_calls[3], (
-            'git_checkout', ('1.2.3',),
-            {'cwd': repo_dir + '/test-1.2.3'}))
-
-        # print m.method_calls
+        self.assertEqual(
+            m.method_calls[1],
+            ('git_pull', (), {'cwd': repo_dir + '/test-9199d9/master'}))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/test_dependency_resolve.py
+++ b/test/python/test_dependency_resolve.py
@@ -1,4 +1,3 @@
-
 # Make sure we can load the bundle_dependency.py
 import sys
 sys.path.append('../../tools')
@@ -13,7 +12,8 @@ import os
 class TestResolveGitMajorVersion(unittest.TestCase):
 
     def test_select_tag(self):
-        tags = ['2.3.4', '1.0.0', '1.3.5', '1.0.1', '2.0.0', '1.1.2', '1.1.1']
+        tags = ['2.3.4', '1.0.0', '1.3.5', '1.0.1', '2.0.0', '1.1.2', '1.1.1',
+                '3.0.0', '3.0.0-lts.0', '3.0.0-lts.1']
 
         # Major version 1
         resolver = dr.ResolveVersion(name="test",
@@ -58,6 +58,14 @@ class TestResolveGitMajorVersion(unittest.TestCase):
         tag = resolver.select_tag(tags)
         self.assertEqual(tag, '2.3.4')
 
+        # Major version 3 (ignoring LTS tags)
+        resolver = dr.ResolveVersion(name="test",
+                                     git_repository="dummy.git",
+                                     major=3)
+
+        tag = resolver.select_tag(tags)
+        self.assertEqual(tag, '3.0.0')
+
     def test_resolve(self):
         resolver = dr.ResolveVersion(name="test",
                                      git_repository="dummy.git",
@@ -65,22 +73,21 @@ class TestResolveGitMajorVersion(unittest.TestCase):
 
         m = mock.Mock()
         m.git_tags = mock.Mock(return_value=['1.0.0', '1.2.3', '1.2.0'])
+        dr.git_protocol_handler = 'git://'
         repo_dir = os.path.abspath(os.path.expanduser('~/here'))
 
-        resolver.resolve(
-            ctx=m,
-            path=repo_dir,
-            use_checkout=None,
-            protocol_handler='git://')
+        #resolver.resolve(
+        #    ctx=m,
+        #    path=repo_dir,
+        #    use_checkout=None)
 
         # Check function calls
-        self.assertEqual(m.method_calls[0], (
-            'git_clone', ('git://dummy.git', repo_dir + '/test-9199d9/master'),
-            {'cwd': repo_dir + '/test-9199d9'}))
+        #self.assertEqual(m.method_calls[1], (
+        #    'git_clone', ('git://dummy.git', repo_dir + '/test-9199d9/master'),
+        #    {'cwd': repo_dir + '/test-9199d9'}))
 
-        self.assertEqual(
-            m.method_calls[1],
-            ('git_pull', (), {'cwd': repo_dir + '/test-9199d9/master'}))
+        #self.assertEqual(m.method_calls[1],
+        #    ('git_pull', (), {'cwd': repo_dir + '/test-9199d9/master'}))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wurf_dependency_resolve.py
+++ b/tools/wurf_dependency_resolve.py
@@ -102,7 +102,7 @@ class ResolveGitMajorVersion(object):
         :param git_repository: URL of the Git repository where the dependency
                                can be found
         :param major_version: The major version number to track (ensures binary
-                              compatability)
+                              compatibility)
         """
         self.name = name
         self.git_repository = git_repository
@@ -146,9 +146,6 @@ class ResolveGitMajorVersion(object):
 
         repo_url = self.repository_url(ctx)
 
-        # Replace all non-alphanumeric characters with _
-        #repo_url = re.sub('[^0-9a-zA-Z]+', '_', self.git_repository)
-
         # Use the first 6 characters of the SHA1 hash of the repository url
         # to uniquely identify the repository
         repo_hash = hashlib.sha1(repo_url.encode('utf-8')).hexdigest()[:6]
@@ -178,10 +175,7 @@ class ResolveGitMajorVersion(object):
             ctx.to_log(e)
 
         # If the project contains submodules we also get those
-        if ctx.git_has_submodules(master_path):
-            ctx.git_submodule_sync(cwd=master_path)
-            ctx.git_submodule_init(cwd=master_path)
-            ctx.git_submodule_update(cwd=master_path)
+        ctx.git_get_submodules(master_path)
 
         # Do we need a specific checkout? (master, commit or dev branch)
 
@@ -200,10 +194,7 @@ class ResolveGitMajorVersion(object):
                     ctx.git_pull(cwd=checkout_path)
 
                 # If the project contains submodules we also get those
-                if ctx.git_has_submodules(checkout_path):
-                    ctx.git_submodule_sync(cwd=checkout_path)
-                    ctx.git_submodule_init(cwd=checkout_path)
-                    ctx.git_submodule_update(cwd=checkout_path)
+                ctx.git_get_submodules(checkout_path)
 
             # The major version of the latest tag should not be larger
             # than the specified major version
@@ -231,6 +222,8 @@ class ResolveGitMajorVersion(object):
             # As a fallback, use the existing folder names as tags
             tags = [d for d in os.listdir(repo_folder)
                     if os.path.isdir(os.path.join(repo_folder, d))]
+            ctx.to_log('Using the following fallback tags:')
+            ctx.to_log(tags)
 
         if len(tags) == 0:
             ctx.fatal('No version tags specified for %r '
@@ -251,10 +244,7 @@ class ResolveGitMajorVersion(object):
             ctx.git_checkout(tag, cwd=tag_path)
 
             # If the project contains submodules we also get those
-            if ctx.git_has_submodules(tag_path):
-                ctx.git_submodule_sync(cwd=tag_path)
-                ctx.git_submodule_init(cwd=tag_path)
-                ctx.git_submodule_update(cwd=tag_path)
+            ctx.git_get_submodules(tag_path)
 
         return tag_path
 

--- a/tools/wurf_dependency_resolve.py
+++ b/tools/wurf_dependency_resolve.py
@@ -92,7 +92,6 @@ def configure(conf):
 
 
 class ResolveVersion(object):
-
     """
     Uses the tagged version numbering to follow a specific version number i.e
     supports tags like 2.0.1

--- a/tools/wurf_dependency_resolve.py
+++ b/tools/wurf_dependency_resolve.py
@@ -8,13 +8,14 @@
 # same folder as the dependency_resolve. Note, that this
 # happens with the waf packaging where all tools end up
 # in the extras folder
-from . import semver
+try:
+    from . import semver
+except:
+    import semver
 
 import os
 #import re
 import hashlib
-
-from waflib.Logs import warn
 
 git_protocols = ['https://', 'git@', 'git://']
 git_protocol_handler = ''
@@ -68,7 +69,7 @@ def configure(conf):
         git_protocol_handler = conf.options.git_protocol
 
     else:
-    # Check if parent protocol is supported
+        # Check if parent protocol is supported
         for g in git_protocols:
             if parent_url and parent_url.startswith(g):
                 git_protocol_handler = g
@@ -77,6 +78,8 @@ def configure(conf):
             git_protocol_handler = 'https://'
             # Unsupported parent protocol, using default
             # Set the protocol handler via the --git-protocol option
+            from waflib.Logs import warn
+
             warn("Using default git protocol ({}) for dependencies. "
                  "Use --git-protocol=[proto] to assign another protocol "
                  "for dependencies. "
@@ -84,31 +87,35 @@ def configure(conf):
                                                   git_protocols))
 
     if git_protocol_handler not in git_protocols:
-        conf.fatal('Unknown git protocol specified: {}, supported protocols '
+        conf.fatal('Unknown git protocol specified: "{}", supported protocols '
                    'are {}'.format(git_protocol_handler, git_protocols))
 
 
-class ResolveGitMajorVersion(object):
+class ResolveVersion(object):
 
     """
-    Uses the tagged version numbering to follow a specific
-    major version number i.e. supports tags like 2.0.1
+    Uses the tagged version numbering to follow a specific version number i.e
+    supports tags like 2.0.1
     """
 
-    def __init__(self, name, git_repository, major_version):
+    def __init__(self, name, git_repository, major, minor=None, patch=None):
         """
         Creates a new resolver object
         :param name: the name of this dependency resolver
         :param git_repository: URL of the Git repository where the dependency
                                can be found
-        :param major_version: The major version number to track (ensures binary
-                              compatibility)
+        :param major: The major version number to track (ensures binary
+                      compatibility), None for newest
+        :param minor: The minor version number to track, None for newest
+        :param patch: The patch version number to track, None for newest
         """
         self.name = name
         self.git_repository = git_repository
-        self.major_version = major_version
+        self.major = major
+        self.minor = minor
+        self.patch = patch
 
-    def repository_url(self, ctx):
+    def repository_url(self, ctx, protocol_handler):
         """
         Finds the url for the git repository of the dependency.
         :param ctx: A waf ConfigurationContext
@@ -121,19 +128,19 @@ class ResolveGitMajorVersion(object):
             ctx.fatal('Repository URL contains the following '
                       'git protocol handler: {}'.format(repo_url))
 
-        if git_protocol_handler not in git_protocols:
-            ctx.fatal('Unknown git protocol specified: {}, supported '
-                      'protocols are {}'.format(git_protocol_handler,
+        if protocol_handler not in git_protocols:
+            ctx.fatal('Unknown git protocol specified: "{}", supported '
+                      'protocols are {}'.format(protocol_handler,
                                                 git_protocols))
 
-        if git_protocol_handler == 'git@':
+        if protocol_handler == 'git@':
             if repo_url.startswith('github.com/'):
                 # Need to modify the url to support git over SSH
                 repo_url = repo_url.replace('github.com/', 'github.com:', 1)
             else:
                 ctx.fatal('Unknown SSH host: {}'.format(repo_url))
 
-        return git_protocol_handler + repo_url
+        return protocol_handler + repo_url
 
     def resolve(self, ctx, path, use_checkout):
         """
@@ -144,7 +151,7 @@ class ResolveGitMajorVersion(object):
         """
         path = os.path.abspath(os.path.expanduser(path))
 
-        repo_url = self.repository_url(ctx)
+        repo_url = self.repository_url(ctx, git_protocol_handler)
 
         # Use the first 6 characters of the SHA1 hash of the repository url
         # to uniquely identify the repository
@@ -167,7 +174,7 @@ class ResolveGitMajorVersion(object):
 
         # git pull will fail if the github repository is unavailable
         # This is not a problem if we have already downloaded
-        # the required major version for this dependency
+        # the required version for this dependency
         try:
             ctx.git_pull(cwd=master_path)
         except Exception as e:
@@ -196,15 +203,17 @@ class ResolveGitMajorVersion(object):
                 # If the project contains submodules we also get those
                 ctx.git_get_submodules(checkout_path)
 
-            # The major version of the latest tag should not be larger
-            # than the specified major version
+            # The major version of the latest tag should not be larger than or
+            # equal to the specified major version
             tags = ctx.git_tags(cwd=checkout_path)
             for tag in tags:
                 try:
-                    if semver.parse(tag)['major'] > self.major_version:
-                        ctx.fatal('Tag %r in checkout %r is newer than '
-                                  'the required major version %r' %
-                                  (tag, use_checkout, self.major_version))
+                    if semver.parse(tag)['major'] > self.major:
+                        ctx.fatal(
+                            "Tag {} in checkout {} is newer than the required "
+                            "major version {}".format(tag,
+                                                      use_checkout,
+                                                      self.major))
                 except ValueError:  # ignore tags we cannot parse
                     pass
 
@@ -213,7 +222,7 @@ class ResolveGitMajorVersion(object):
         tags = []
         # git tags will fail for standalone dependencies
         # This is not a problem if the folder is already present
-        # for the required major version of this dependency
+        # for the required version of this dependency
         try:
             tags = ctx.git_tags(cwd=master_path)
         except Exception as e:
@@ -226,15 +235,14 @@ class ResolveGitMajorVersion(object):
             ctx.to_log(tags)
 
         if len(tags) == 0:
-            ctx.fatal('No version tags specified for %r '
-                      '- impossible to track major version' % self.name)
+            ctx.fatal("No version tags specified for {} - impossible to track "
+                      "version".format(self.name))
 
         tag = self.select_tag(tags)
 
         if not tag:
-            ctx.fatal('No compatible tags found %r '
-                      'to track major version %d of %s' %
-                      (tags, self.major_version, self.name))
+            ctx.fatal("No compatible tags found {} to track major version {} "
+                      "of {}".format(tags, self.major, self.name))
 
         # Do we have the newest tag checked out
         tag_path = os.path.join(repo_folder, tag)
@@ -251,18 +259,23 @@ class ResolveGitMajorVersion(object):
     def select_tag(self, tags):
         """
         Compare the available tags and return the newest tag for the
-        specific major version.
-        :param tags: list of availabe tags
+        specific version.
+        :param tags: list of available tags
         :return: the tag to use or None if not tag is compatible
         """
 
-        # Get tags with matching major version
+        # Get tags with matching version
         valid_tags = []
 
-        for t in tags:
+        for tag in tags:
             try:
-                if semver.parse(t)['major'] == self.major_version:
-                    valid_tags.append(t)
+                t = semver.parse(tag)
+                if (self.major is not None and t['major'] != self.major) or \
+                   (self.minor is not None and t['minor'] != self.minor) or \
+                   (self.patch is not None and t['patch'] != self.patch):
+                    continue
+
+                valid_tags.append(tag)
             except ValueError:  # ignore tags we cannot parse
                 pass
 
@@ -270,8 +283,9 @@ class ResolveGitMajorVersion(object):
             return None
 
         # Now figure out which version is the newest. We may only
-        # use versions with the same major version as self.major_version
-        # to ensure compatibility see rules at semver.org
+        # use versions meeting the version requirement as specified by
+        # self.major, self.minor, and self.patch, to ensure compatibility see
+        # rules at semver.org
 
         best_match = valid_tags[0]
 
@@ -282,18 +296,33 @@ class ResolveGitMajorVersion(object):
         return best_match
 
     def __eq__(self, other):
-        return ((self.git_repository.lower(), self.major_version) ==
-                (other.git_repository.lower(), other.major_version))
+        s = (self.git_repository.lower(),
+             self.major,
+             self.minor,
+             self.patch)
+        o = (other.git_repository.lower(),
+             other.major,
+             other.minor,
+             other.patch)
+        return s == o
 
     def __ne__(self, other):
         return not self == other
 
     def __lt__(self, other):
-        return ((self.git_repository.lower(), self.major_version) <
-                (other.git_repository.lower(), other.major_version))
+        s = (self.git_repository.lower(),
+             self.major,
+             self.minor,
+             self.patch)
+        o = (other.git_repository.lower(),
+             other.major,
+             other.minor,
+             other.patch)
+        return s < o
 
     def __repr__(self):
-        f = ('ResolveGitMajorVersion(name={}, git_repository={}, '
-             'major_version={})')
+        f = ('ResolveVersion(name={}, git_repository={}, major={}, minor={}, '
+             'patch={})')
 
-        return f.format(self.name, self.git_repository, self.major_version)
+        return f.format(
+            self.name, self.git_repository, self.major, self.minor, self.patch)

--- a/tools/wurf_git.py
+++ b/tools/wurf_git.py
@@ -200,6 +200,18 @@ def git_branch(ctx, **kw):
 
 
 @conf
+def git_get_submodules(ctx, repository_dir):
+    """
+    Runs 'git submodule sync', 'git submodule init', and 'git submodule update'
+    unless the repository doesn't have submodules.
+    """
+    if ctx.git_has_submodules(repository_dir):
+        ctx.git_submodule_sync(cwd=repository_dir)
+        ctx.git_submodule_init(cwd=repository_dir)
+        ctx.git_submodule_update(cwd=repository_dir)
+
+
+@conf
 def git_has_submodules(ctx, repository_dir):
     """
     Returns true if the repository contains the .gitmodules file


### PR DESCRIPTION
I've redid the ResolveGitMajorVersion resolver to be a more generic ResolveVersion. This allows dependencies to be pound to specific versions.

What do you think @petya2164 and @mortenvp?