### PR TITLE
reversed dependency build order

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,7 +6,7 @@ of every change, see the Git log.
 
 Latest
 ------
-* tbd
+* Patch: Reversed dependency build order.
 
 5.0.0
 -----

--- a/tools/wurf_dependency_bundle.py
+++ b/tools/wurf_dependency_bundle.py
@@ -211,7 +211,9 @@ def build(bld):
     # The BuildContext reloads the environment of the ConfigurationContext,
     # so the dependencies will be enumerated in the same order as
     # in the configure step
-    for path in bld.env['DEPENDENCY_LIST']:
+    # We need to build the dependencies in the reveresed order they were
+    # appended to ensure that dependencies dependencies are available.
+    for path in reversed(bld.env['DEPENDENCY_LIST']):
         bld.recurse([path])
 
 

--- a/tools/wurf_dependency_bundle.py
+++ b/tools/wurf_dependency_bundle.py
@@ -209,10 +209,9 @@ def configure(conf):
 
 def build(bld):
     # The BuildContext reloads the environment of the ConfigurationContext,
-    # so the dependencies will be enumerated in the same order as
-    # in the configure step
-    # We need to build the dependencies in the reveresed order they were
-    # appended to ensure that dependencies dependencies are available.
+    # so the DEPENDENCY_LIST will be the same, but in the build step we
+    # recurse into the dependencies in the reverse order to avoid potential
+    # issues with tasks that are defined by a dependency of a dependency.
     for path in reversed(bld.env['DEPENDENCY_LIST']):
         bld.recurse([path])
 


### PR DESCRIPTION
@petya2164 do you agree with this change? I had some issues when trying to make kodo-cpp depend on the new version of kodo-c. It seems that kodo_includes are not available when trying to build kodo-c because of the order the dependencies are appended. 