### PR TITLE
using argparse to get value of dependency path specified at commandline

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,8 @@ of every change, see the Git log.
 
 Latest
 ------
+* Minor: Allow option arguments without the = sign for the options that are
+  defined and used in the resolve step (--%s-path and --%s-use-checkout).
 * Patch: Reversed dependency build order.
 
 5.0.0

--- a/tools/wurf_dependency_bundle.py
+++ b/tools/wurf_dependency_bundle.py
@@ -72,12 +72,12 @@ def add_dependency(ctx, resolver, recursive_resolve=True):
 
         add('--%s-path' % name,
             dest=DEPENDENCY_PATH_KEY % name,
-            default=False,
+            default=None,
             help='Path to %s' % name)
 
         add('--%s-use-checkout' % name,
             dest=DEPENDENCY_CHECKOUT_KEY % name,
-            default=False,
+            default=None,
             help='The checkout to use for %s' % name)
 
         # The dependency resolvers are allowed to download dependencies
@@ -124,7 +124,10 @@ def options(opt):
 
 
 def resolve_dependency(ctx, name):
-
+    # The --%s-path option is parsed directly here, since we want to allow
+    # option arguments without the = sign, e.g. --xy-path my-path-to-xy
+    # We cannot use ctx.options where --xy-path would be handled as a
+    # standalone boolean option (which has no arguments)
     p = argparse.ArgumentParser()
     p.add_argument('--%s-path' % name, dest='dependency_path', type=str)
     args, unknown = p.parse_known_args(args=sys.argv[1:])
@@ -146,8 +149,13 @@ def resolve_dependency(ctx, name):
 
         ctx.start_msg('Resolve dependency %s' % name)
 
-        key = DEPENDENCY_CHECKOUT_KEY % name
-        dependency_checkout = getattr(ctx.options, key, None)
+        # The --%s-use-checkout option is parsed directly, since we want to
+        # allow option arguments without the = sign
+        p = argparse.ArgumentParser()
+        p.add_argument('--%s-use-checkout' % name, dest='dependency_checkout',
+                       type=str)
+        args, unknown = p.parse_known_args(args=sys.argv[1:])
+        dependency_checkout = args.dependency_checkout
 
         dependency_path = dependencies[name].resolve(
             ctx=ctx,

--- a/tools/wurf_dependency_bundle.py
+++ b/tools/wurf_dependency_bundle.py
@@ -11,6 +11,8 @@ This tool is loaded automatically in "wurf_common_tools".
 """
 
 import os
+import sys
+import argparse
 
 from waflib.Configure import conf
 from waflib import Utils
@@ -123,9 +125,10 @@ def options(opt):
 
 def resolve_dependency(ctx, name):
 
-    # If the user specified a path for this dependency
-    key = DEPENDENCY_PATH_KEY % name
-    dependency_path = getattr(ctx.options, key, None)
+    p = argparse.ArgumentParser()
+    p.add_argument('--%s-path' % name, dest='dependency_path', type=str)
+    args, unknown = p.parse_known_args(args=sys.argv[1:])
+    dependency_path = args.dependency_path
 
     if dependency_path:
 


### PR DESCRIPTION
With this patch it is now (again) possible to configure dependency paths without using "=". 
Example: "--kodo-path ../kodo" instead of "--kodo-path=../kodo" (both work now)