### PR TITLE
Add fast resolve

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,11 @@ of every change, see the Git log.
 
 Latest
 ------
+* Major: Full rewrite of our Waf depedency resolve code.
+* Minor: Adding support for `--fast-resolve` option
+
+Un-released changes
+-------------------
 * Minor: Allow arbitrary git providers in wurf_dependency_resolve.
 * Minor: Allow optional dependencies that might not be resolved if they are
   unavailable to the user.

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,12 @@ Providing the `--fast-resolve` option should only invoke the resolvers for
 dependencies that have not already been downloaded. Already downloaded
 dependencies should be loaded from the cache.
 
+`--fast-resolve` is also useful when manually specifying resolve method for a
+dependency e.g. to manually set the path of a dependency `foo` using
+`--fast-resolve` will load all other dependencies from cache::
+
+    python waf configure --foo-path /tmp/foo --fast-resolve
+
 Future features
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -93,21 +93,35 @@ to your wscript's upload function::
         waf_resolve_context.recurse_dependencies(self)
 
 
-Features
-========
+Options (building new Waf binaries)
+===================================
 
 `--skip_network_tests`
 ---------------------------
 To test the freshly built Waf binary some unit test use network connectivity
-to resolve dependencies. This makes the tests slow. It would therefore be 
+to resolve dependencies. This makes the tests slow. It would therefore be
 beneficial to remove these tests when running e.g. on a build system.
 
-An example of such a test is the `self_build` test. The `self_build` test will 
+An example of such a test is the `self_build` test. The `self_build` test will
 invoke a freshly built `waf` binary with the wscript used to build it -
 yes very meta :)
 
 Passing `--skip_network_tests` will skip any unit tests which rely on network
 connectivity.
+
+Features of Waf with resolve capabilities
+=========================================
+
+`--fast-resolve`
+----------------
+As default the resolver will be invoked when configuring a waf project i.e.
+invoking `python waf configure ...`. Depending on the number of dependencies
+this may take some time to complete. This is problematic if an user is for
+example re-configuring to change compiler.
+
+Providing the `--fast-resolve` option should only invoke the resolvers for
+dependencies that have not already been downloaded. Already downloaded
+dependencies should be loaded from the cache.
 
 Future features
 ===============
@@ -161,17 +175,6 @@ Certain resolvers utilize "shortcuts" such as using cached information about
 dependencies to speed the resolve step. Providing this option should by-pass
 such optimizations and do a full resolve - not relying on any form of cached
 data.
-
-Add `--no-resolve` option
--------------------------
-As default the resolver will be invoked when configuring a waf project i.e.
-invoking `python waf configure ...`. Depending on the number of dependencies
-this may take some time to complete. This is problematic if an user is for
-example re-configuring to change compiler.
-
-Providing the `--fast-resolve` option should only invoke the resolvers for
-dependencies that have not already been downloaded. Already downloaded
-dependencies should be loaded from the cache.
 
 Add support for `dependencies.json`
 -----------------------------------

--- a/src/wurf/create_symlink_resolver.py
+++ b/src/wurf/create_symlink_resolver.py
@@ -38,6 +38,10 @@ class CreateSymlinkResolver(object):
         link_name = self.dependency.name
         link_path = os.path.join(self.symlinks_path, link_name)
 
+        if link_path == path:
+            # Symlink is already in place. We may have loaded it from cache.
+            return path
+
         # os.symlink() is not available in Python 2.7 on Windows.
         # We use the original function if it is available, otherwise we
         # create a helper function for Windows

--- a/src/wurf/on_passive_load_path_resolver.py
+++ b/src/wurf/on_passive_load_path_resolver.py
@@ -40,7 +40,7 @@ class OnPassiveLoadPathResolver(object):
         path = str(config['path'])
 
         if not os.path.isdir(path):
-            raise DependencyErrors('Not valid path {}'.format(path),
+            raise DependencyError('Not valid path {}'.format(path),
                 self.dependency)
 
         return path

--- a/src/wurf/options.py
+++ b/src/wurf/options.py
@@ -32,6 +32,12 @@ class Options(object):
             help='The folder where the dependency symlinks are placed.'
                  '(default: %(default)s)')
 
+        self.parser.add_argument('--fast-resolve', dest='--fast-resolve',
+            action='store_true', default=False,
+            help='Load already resolved dependencies from file system. '
+                  'Useful for running configure without resolving dependencies '
+                  'again.')
+
         self.__parse()
 
     def bundle_path(self):
@@ -42,6 +48,9 @@ class Options(object):
 
     def git_protocol(self):
         return self.known_args['--git-protocol']
+
+    def fast_resolve(self):
+        return self.known_args['--fast-resolve']
 
     def path(self, dependency):
         return self.known_args['--%s-path' % dependency.name]

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -327,7 +327,7 @@ def user_path_resolver(registry, dependency):
     path = mandatory_options.path(dependency=dependency)
 
     ctx = registry.require('ctx')
-    
+
     # Set the resolver method on the dependency
     dependency.resolver_method = 'User'
 
@@ -510,9 +510,23 @@ def git_source_resolver(registry, dependency):
     if checkout:
         return registry.require('git_user_checkout_resolver',
             dependency=dependency)
+
+    method_key = "git_{}_resolver".format(dependency.method)
+    git_resolver = registry.require(method_key, dependency=dependency)
+
+    if options.fast_resolve():
+        bundle_config_path = registry.require('bundle_config_path')
+
+        fast_resolver = OnPassiveLoadPathResolver(dependency=dependency,
+            bundle_config_path=bundle_config_path)
+
+        fast_resolver = TryResolver(resolver=fast_resolver, ctx=ctx)
+
+        return ListResolver(resolvers=[fast_resolver, git_resolver])
+
     else:
-        method_key = "git_{}_resolver".format(dependency.method)
-        return registry.require(method_key, dependency=dependency)
+
+        return git_resolver
 
 
 @Registry.provide
@@ -529,7 +543,7 @@ def help_dependency_resolver(registry, dependency):
 
     resolver = TryResolver(resolver=resolver, ctx=ctx)
 
-    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx, 
+    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx,
         dependency=dependency)
 
     return resolver
@@ -548,7 +562,7 @@ def passive_dependency_resolver(registry, dependency):
 
     resolver = TryResolver(resolver=resolver, ctx=ctx)
 
-    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx, 
+    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx,
         dependency=dependency)
 
     resolver = CheckOptionalResolver(resolver=resolver,
@@ -573,8 +587,8 @@ def active_dependency_resolver(registry, dependency):
     resolver = CreateSymlinkResolver(
         resolver=resolver, dependency=dependency, symlinks_path=symlinks_path,
         ctx=ctx)
-        
-    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx, 
+
+    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx,
         dependency=dependency)
 
     return OnActiveStorePathResolver(
@@ -592,8 +606,8 @@ def dependency_resolver(registry, dependency):
     # There are three resolver chains/configurations:
     #
     # 1. The "active" chain: This chain goes to the network and fetches stuff
-    # 2. The "passive" chain: This chain will load information from the
-    #    file system.
+    # 2. The "passive" or "no-resolve" chain: This chain will load information
+    #    from the file system.
     # 3. The "help" chain: This chain tries to interate though as many
     #    dependencies as possible to get all options.
 

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -515,6 +515,10 @@ def git_source_resolver(registry, dependency):
     git_resolver = registry.require(method_key, dependency=dependency)
 
     if options.fast_resolve():
+
+        # Set the resolver method on the dependency
+        dependency.resolver_action = 'fast/'+dependency.resolver_action
+
         bundle_config_path = registry.require('bundle_config_path')
 
         fast_resolver = OnPassiveLoadPathResolver(dependency=dependency,

--- a/test/add_dependency/test_add_dependency.py
+++ b/test/add_dependency/test_add_dependency.py
@@ -115,6 +115,8 @@ def test_add_dependency(test_directory):
     assert os.path.exists(os.path.join(app_dir.path(), 'build_symlinks', 'bar'))
 
     app_dir.run('python', 'waf', 'build', '-v')
+    app_dir.run('python', 'waf', 'configure', '-v', '--fast-resolve')
+    app_dir.run('python', 'waf', 'build', '-v')
 
 
 def test_add_dependency_path(test_directory):
@@ -141,3 +143,4 @@ def test_add_dependency_path(test_directory):
     assert os.path.exists(os.path.join(app_dir.path(), 'build_symlinks', 'bar'))
 
     app_dir.run('python', 'waf', 'build', '-v')
+    app_dir.run('python', 'waf', 'configure', '-v', '--fast-resolve')


### PR DESCRIPTION
Support the --fast-resolve option.

Note it is added deeper in the resolver hierarchy than I originally wanted. But I placed it there to support user overriding with `--foo-use-checkout` `--foo-path` options etc, and to support fetching only a newly added or changed dependency.