### PR TITLE
Improve messages and paths in ContextMsgResolver

### DIFF
--- a/src/wurf/context_msg_resolver.py
+++ b/src/wurf/context_msg_resolver.py
@@ -24,10 +24,12 @@ class ContextMsgResolver(object):
 
         :return: The path as a string.
         """
-        
 
-        self.ctx.start_msg('{} {}'.format(
-            self.dependency.resolver_method, self.dependency.name))
+        start_msg = '{} "{}"'.format(
+            self.dependency.resolver_action, self.dependency.name)
+        if self.dependency.resolver_method:
+            start_msg += ' ({})'.format(self.dependency.resolver_method)
+        self.ctx.start_msg(start_msg)
 
         path = self.resolver.resolve()
 
@@ -37,10 +39,16 @@ class ContextMsgResolver(object):
             # print the status message and continue
             self.ctx.end_msg('Unavailable', color='RED')
         else:
-            
+
             if self.dependency.is_symlink:
+                # We print the symlink path as a relative path if it is
+                # inside the project folder
+                symlink_path = path
+                symlink_node = self.ctx.root.find_dir(path)
+                if symlink_node.is_child_of(self.ctx.srcnode):
+                    symlink_path = symlink_node.path_from(self.ctx.srcnode)
                 real_path = self.dependency.real_path
-                self.ctx.end_msg("{} => {}".format(path, real_path))
+                self.ctx.end_msg("{} => {}".format(symlink_path, real_path))
             else:
                 self.ctx.end_msg(path)
 

--- a/src/wurf/context_msg_resolver.py
+++ b/src/wurf/context_msg_resolver.py
@@ -16,19 +16,27 @@ class ContextMsgResolver(object):
         self.dependency = dependency
 
     def resolve(self):
-        """ Resolve a path to a dependency.
+        """ Print the resolved path to the terminal using Waf's Context.
 
-        If we are doing an "passive" resolver, meaning that waf was not invoked
-        with configure. Then we load the resolved path to the file-system.
-        Otherwise we raise an exception.
+        The print will format the start message differently depending on the
+        "resolver_chain" and "resolver_action" attributes of the dependency
+        object.
+
+        Finally the path will be printed different depending on the "is_symlink"
+        and "real_path" dependency object attributes.
+
+        See a description of these attributes in the Depencency object docs.
+
+        If the path is a symbolic link we print both the symbolic link and
+        actual path on the file-system.
 
         :return: The path as a string.
         """
 
         start_msg = '{} "{}"'.format(
-            self.dependency.resolver_action, self.dependency.name)
-        if self.dependency.resolver_method:
-            start_msg += ' ({})'.format(self.dependency.resolver_method)
+            self.dependency.resolver_chain, self.dependency.name)
+        if self.dependency.resolver_action:
+            start_msg += ' ({})'.format(self.dependency.resolver_action)
         self.ctx.start_msg(start_msg)
 
         path = self.resolver.resolve()

--- a/src/wurf/dependency.py
+++ b/src/wurf/dependency.py
@@ -49,7 +49,22 @@ class Dependency(object):
         read-only: name, recurse, optional, resolver, method, checkout,
         sources and sha1.
 
-        Any other attributes can be added and modified as needed.
+        Any other attributes can be added and modified as needed. The following
+        documents used attributes with reserved meaning:
+
+        - "is_symlink" and "real_path": The "is_symlink" attribute denotes
+          whether the path returned by the resolver is a symbolic link. If
+          this is the case the "real_path" attribute of the dependency will
+          contain the path in the file-system which the symbolic link points
+          to.
+
+        - "resolver_chain": The "resolver_chain" this attribute assigns a
+          high-level name to the the chain of resolvers e.g. such as "Resolve",
+          "Load". This describes the high-level operation of the resolver chain.
+
+        - "resolver_action": The "resolver_action" this attribute describes the
+          specific action taken to resolve the dependency. For example:
+          "git checkout", "user path" etc. 
 
         :param kwargs: Keyword arguments containing options for the dependency.
         """

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -329,7 +329,7 @@ def user_path_resolver(registry, dependency):
     ctx = registry.require('ctx')
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'user path'
+    dependency.resolver_action = 'user path'
 
     resolver = UserPathResolver(dependency=dependency, path=path)
 
@@ -423,7 +423,7 @@ def git_checkout_resolver(registry, dependency):
     ctx = registry.require('ctx')
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'git checkout'
+    dependency.resolver_action = 'git checkout'
 
     resolver = registry.require('git_checkout_list_resolver',
         dependency=dependency, checkout=dependency.checkout)
@@ -452,7 +452,7 @@ def git_semver_resolver(registry, dependency):
     major = dependency.major
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'git semver'
+    dependency.resolver_action = 'git semver'
 
     def wrap(resolver):
         resolver = GitSemverResolver(git=git, git_resolver=resolver, ctx=ctx,
@@ -483,7 +483,7 @@ def git_user_checkout_resolver(registry, dependency):
     checkout = mandatory_options.use_checkout(dependency=dependency)
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'git user checkout'
+    dependency.resolver_action = 'git user checkout'
 
     # When the user specified the checkout one must succeed:
     resolver = registry.require('git_checkout_list_resolver',
@@ -522,7 +522,7 @@ def help_dependency_resolver(registry, dependency):
     bundle_config_path = registry.require('bundle_config_path')
 
     # Set the resolver action on the dependency
-    dependency.resolver_action = 'Load (help)'
+    dependency.resolver_chain = 'Load (help)'
 
     resolver = OnPassiveLoadPathResolver(dependency=dependency,
         bundle_config_path=bundle_config_path)
@@ -541,7 +541,7 @@ def passive_dependency_resolver(registry, dependency):
     bundle_config_path = registry.require('bundle_config_path')
 
     # Set the resolver action on the dependency
-    dependency.resolver_action = 'Load'
+    dependency.resolver_chain = 'Load'
 
     resolver = OnPassiveLoadPathResolver(dependency=dependency,
         bundle_config_path=bundle_config_path)
@@ -565,7 +565,7 @@ def active_dependency_resolver(registry, dependency):
     symlinks_path = registry.require('symlinks_path')
 
     # Set the resolver action on the dependency
-    dependency.resolver_action = 'Resolve'
+    dependency.resolver_chain = 'Resolve'
 
     if options.path(dependency=dependency):
         resolver = registry.require('user_path_resolver', dependency=dependency)
@@ -592,7 +592,7 @@ def dependency_resolver(registry, dependency):
     # This is where we "wire" together the resolvers. Which actually do the
     # work of via some method obtaining a path to a dependency.
     #
-    # There are three resolver chains/configurations:
+    # There are three main resolver chains/configurations:
     #
     # 1. The "active" chain: This chain goes to the network and fetches stuff
     # 2. The "passive" chain: This chain will load information from the

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -327,9 +327,9 @@ def user_path_resolver(registry, dependency):
     path = mandatory_options.path(dependency=dependency)
 
     ctx = registry.require('ctx')
-    
+
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'User'
+    dependency.resolver_method = 'user path'
 
     resolver = UserPathResolver(dependency=dependency, path=path)
 
@@ -423,7 +423,7 @@ def git_checkout_resolver(registry, dependency):
     ctx = registry.require('ctx')
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'Git checkout'
+    dependency.resolver_method = 'git checkout'
 
     resolver = registry.require('git_checkout_list_resolver',
         dependency=dependency, checkout=dependency.checkout)
@@ -452,7 +452,7 @@ def git_semver_resolver(registry, dependency):
     major = dependency.major
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'Git semver'
+    dependency.resolver_method = 'git semver'
 
     def wrap(resolver):
         resolver = GitSemverResolver(git=git, git_resolver=resolver, ctx=ctx,
@@ -483,7 +483,7 @@ def git_user_checkout_resolver(registry, dependency):
     checkout = mandatory_options.use_checkout(dependency=dependency)
 
     # Set the resolver method on the dependency
-    dependency.resolver_method = 'Git user checkout'
+    dependency.resolver_method = 'git user checkout'
 
     # When the user specified the checkout one must succeed:
     resolver = registry.require('git_checkout_list_resolver',
@@ -521,15 +521,15 @@ def help_dependency_resolver(registry, dependency):
     ctx = registry.require('ctx')
     bundle_config_path = registry.require('bundle_config_path')
 
-    # Set the resolver method on the dependency
-    dependency.resolver_method = 'Load (help)'
+    # Set the resolver action on the dependency
+    dependency.resolver_action = 'Load (help)'
 
     resolver = OnPassiveLoadPathResolver(dependency=dependency,
         bundle_config_path=bundle_config_path)
 
     resolver = TryResolver(resolver=resolver, ctx=ctx)
 
-    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx, 
+    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx,
         dependency=dependency)
 
     return resolver
@@ -540,15 +540,15 @@ def passive_dependency_resolver(registry, dependency):
     ctx = registry.require('ctx')
     bundle_config_path = registry.require('bundle_config_path')
 
-    # Set the resolver method on the dependency
-    dependency.resolver_method = 'Load'
+    # Set the resolver action on the dependency
+    dependency.resolver_action = 'Load'
 
     resolver = OnPassiveLoadPathResolver(dependency=dependency,
         bundle_config_path=bundle_config_path)
 
     resolver = TryResolver(resolver=resolver, ctx=ctx)
 
-    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx, 
+    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx,
         dependency=dependency)
 
     resolver = CheckOptionalResolver(resolver=resolver,
@@ -564,6 +564,9 @@ def active_dependency_resolver(registry, dependency):
     bundle_config_path = registry.require('bundle_config_path')
     symlinks_path = registry.require('symlinks_path')
 
+    # Set the resolver action on the dependency
+    dependency.resolver_action = 'Resolve'
+
     if options.path(dependency=dependency):
         resolver = registry.require('user_path_resolver', dependency=dependency)
     else:
@@ -573,8 +576,8 @@ def active_dependency_resolver(registry, dependency):
     resolver = CreateSymlinkResolver(
         resolver=resolver, dependency=dependency, symlinks_path=symlinks_path,
         ctx=ctx)
-        
-    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx, 
+
+    resolver = ContextMsgResolver(resolver=resolver, ctx=ctx,
         dependency=dependency)
 
     return OnActiveStorePathResolver(


### PR DESCRIPTION
@mortenvp I changed the format of start_msg in ContextMsgResolver as I explained before.
Furthermore, the symlink_path is printed as a relative path to make the path output readable and much shorter ;)
You can see how it looks here:
http://buildbot.steinwurf.dk/builders/cpp-tester-archlinux_64-cxx_gxx63_x64-py36_x64/builds/53/steps/configure/logs/stdio

I guess the `resolve_action` can be set to `Load` if you configure with `--fast-resolve` and you already had that dependency. Or we can come up with a different designation for that case.