### PR TITLE
Use underscore in all options + Shorten project_use_checkout to project_checkout

### DIFF
--- a/src/wurf/options.py
+++ b/src/wurf/options.py
@@ -15,24 +15,24 @@ class Options(object):
 
         # Using the %default placeholder:
         #    http://stackoverflow.com/a/1254491/1717320
-        self.parser.add_argument('--bundle-path',
+        self.parser.add_argument('--bundle_path',
             default=default_bundle_path,
-            dest='--bundle-path',
+            dest='--bundle_path',
             help='The folder where the bundled dependencies are downloaded.'
                  '(default: %(default)s)')
 
-        self.parser.add_argument('--git-protocol',
-            dest='--git-protocol',
+        self.parser.add_argument('--git_protocol',
+            dest='--git_protocol',
             help='Use a specific git protocol to download dependencies.'
                  'Supported protocols {}'.format(supported_git_protocols))
 
-        self.parser.add_argument('--symlinks-path',
+        self.parser.add_argument('--symlinks_path',
             default=default_symlinks_path,
-            dest='--symlinks-path',
+            dest='--symlinks_path',
             help='The folder where the dependency symlinks are placed.'
                  '(default: %(default)s)')
 
-        self.parser.add_argument('--fast-resolve', dest='--fast-resolve',
+        self.parser.add_argument('--fast_resolve', dest='--fast_resolve',
             action='store_true', default=False,
             help='Load already resolved dependencies from file system. '
                   'Useful for running configure without resolving dependencies '
@@ -41,22 +41,22 @@ class Options(object):
         self.__parse()
 
     def bundle_path(self):
-        return self.known_args['--bundle-path']
+        return self.known_args['--bundle_path']
 
     def symlinks_path(self):
-        return self.known_args['--symlinks-path']
+        return self.known_args['--symlinks_path']
 
     def git_protocol(self):
-        return self.known_args['--git-protocol']
+        return self.known_args['--git_protocol']
 
     def fast_resolve(self):
-        return self.known_args['--fast-resolve']
+        return self.known_args['--fast_resolve']
 
     def path(self, dependency):
-        return self.known_args['--%s-path' % dependency.name]
+        return self.known_args['--%s_path' % dependency.name]
 
-    def use_checkout(self, dependency):
-        return self.known_args['--%s-use-checkout' % dependency.name]
+    def checkout(self, dependency):
+        return self.known_args['--%s_checkout' % dependency.name]
 
     def __parse(self):
 
@@ -67,7 +67,7 @@ class Options(object):
 
     def __add_path(self, dependency):
 
-        option = '--%s-path' % dependency.name
+        option = '--%s_path' % dependency.name
 
         self.parser.add_argument(option,
             nargs='?',
@@ -75,9 +75,9 @@ class Options(object):
             help='Manually specify path for {}.'.format(
                 dependency.name))
 
-    def __add_use_checkout(self, dependency):
+    def __add_checkout(self, dependency):
 
-        option = '--%s-use-checkout' % dependency.name
+        option = '--%s_checkout' % dependency.name
 
         self.parser.add_argument(option,
             nargs='?',
@@ -91,6 +91,6 @@ class Options(object):
 
         if dependency.resolver == 'git':
 
-            self.__add_use_checkout(dependency)
+            self.__add_checkout(dependency)
 
         self.__parse()

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -480,7 +480,7 @@ def git_user_checkout_resolver(registry, dependency):
     ctx = registry.require('ctx')
 
     mandatory_options = registry.require('mandatory_options')
-    checkout = mandatory_options.use_checkout(dependency=dependency)
+    checkout = mandatory_options.checkout(dependency=dependency)
 
     # Set the resolver method on the dependency
     dependency.resolver_action = 'git user checkout'
@@ -504,7 +504,7 @@ def git_source_resolver(registry, dependency):
     """
     ctx = registry.require('ctx')
     options = registry.require('options')
-    checkout = options.use_checkout(dependency=dependency)
+    checkout = options.checkout(dependency=dependency)
 
     # If the user specified a checkout we should use that
     if checkout:

--- a/test/add_dependency/test_add_dependency.py
+++ b/test/add_dependency/test_add_dependency.py
@@ -178,7 +178,7 @@ def test_resolve_json(test_directory):
     assert os.path.exists(os.path.join(app_dir.path(), 'build_symlinks', 'bar'))
 
     app_dir.run('python', 'waf', 'build', '-v')
-    app_dir.run('python', 'waf', 'configure', '-v', '--fast-resolve')
+    app_dir.run('python', 'waf', 'configure', '-v', '--fast_resolve')
     app_dir.run('python', 'waf', 'build', '-v')
 
 
@@ -227,7 +227,7 @@ def test_add_dependency(test_directory):
     assert os.path.exists(os.path.join(app_dir.path(), 'build_symlinks', 'bar'))
 
     app_dir.run('python', 'waf', 'build', '-v')
-    app_dir.run('python', 'waf', 'configure', '-v', '--fast-resolve')
+    app_dir.run('python', 'waf', 'configure', '-v', '--fast_resolve')
     app_dir.run('python', 'waf', 'build', '-v')
 
 
@@ -257,7 +257,7 @@ def test_add_dependency_path(test_directory):
     path_test = test_directory.mkdir(directory='path_test')
     baz_dir = mkdir_libbaz(directory=path_test)
 
-    app_dir.run('python', 'waf', 'configure', '-v', '--baz-path={}'.format(
+    app_dir.run('python', 'waf', 'configure', '-v', '--baz_path={}'.format(
                 baz_dir.path()))
 
     # The symlinks should be available to all dependencies
@@ -266,4 +266,4 @@ def test_add_dependency_path(test_directory):
     assert os.path.exists(os.path.join(app_dir.path(), 'build_symlinks', 'bar'))
 
     app_dir.run('python', 'waf', 'build', '-v')
-    app_dir.run('python', 'waf', 'configure', '-v', '--fast-resolve')
+    app_dir.run('python', 'waf', 'configure', '-v', '--fast_resolve')

--- a/test/python/test_options.py
+++ b/test/python/test_options.py
@@ -20,7 +20,7 @@ def test_bundle_path():
 
 
     parser = argparse.ArgumentParser()
-    args = ['--foo', '--bundle-path', '/tmp/bundlehere', '-b']
+    args = ['--foo', '--bundle_path', '/tmp/bundlehere', '-b']
 
     options = Options(args=args, parser=parser, default_bundle_path="",
         default_symlinks_path="", supported_git_protocols="")
@@ -48,7 +48,7 @@ def test_symlinks_path():
     assert options.symlinks_path() == default_path
 
     parser = argparse.ArgumentParser()
-    args = ['--foo', '--symlinks-path', '/tmp/symlinks', '-b']
+    args = ['--foo', '--symlinks_path', '/tmp/symlinks', '-b']
 
     options = Options(args=args, parser=parser, default_bundle_path="",
         default_symlinks_path=default_path, supported_git_protocols="")
@@ -63,8 +63,8 @@ def test_user_path_to_dependency():
 
     # Path specified
     parser = argparse.ArgumentParser()
-    args = ['--foo', '--bundle-path', '/tmp/bundlehere',
-            '--foo-path', '/home/stw/code', '-b']
+    args = ['--foo', '--bundle_path', '/tmp/bundlehere',
+            '--foo_path', '/home/stw/code', '-b']
 
     options = Options(args=args, parser=parser, default_bundle_path="",
         default_symlinks_path="", supported_git_protocols="")
@@ -75,8 +75,8 @@ def test_user_path_to_dependency():
 
     # Path specified
     parser = argparse.ArgumentParser()
-    args = ['--foo', '--bundle-path', '/tmp/bundlehere',
-            '--foo-path', '/home/stw/code1', '-b']
+    args = ['--foo', '--bundle_path', '/tmp/bundlehere',
+            '--foo_path', '/home/stw/code1', '-b']
 
     options = Options(args=args, parser=parser, default_bundle_path="",
         default_symlinks_path="", supported_git_protocols="")
@@ -97,7 +97,7 @@ def test_git_protocol():
     assert options.git_protocol() == None
 
     parser = argparse.ArgumentParser()
-    args = ['--foo', '--git-protocol', 'myproto://', '-b']
+    args = ['--foo', '--git_protocol', 'myproto://', '-b']
 
     options = Options(args=args, parser=parser, default_bundle_path="",
         default_symlinks_path="", supported_git_protocols="")
@@ -116,7 +116,7 @@ def test_fast_resolve():
     assert options.fast_resolve() == False
 
     parser = argparse.ArgumentParser()
-    args = ['--foo', '--fast-resolve', '-b']
+    args = ['--foo', '--fast_resolve', '-b']
 
     options = Options(args=args, parser=parser, default_bundle_path="",
         default_symlinks_path="", supported_git_protocols="")


### PR DESCRIPTION
@mortenvp Take a look here, I think underscore is the way to go! I saw that you also followed this convention when adding new options.
I also shortened `xyz_use_checkout` to `xyz_checkout`, because that's more consistent with `xyz_path`.