### PR TITLE
Prepare for release

### DIFF
--- a/src/wurf/create_symlink_resolver.py
+++ b/src/wurf/create_symlink_resolver.py
@@ -38,6 +38,8 @@ class CreateSymlinkResolver(object):
         link_path = os.path.join(self.symlinks_path, self.dependency.name)
 
         if os.path.exists(link_path):
+            # On Windows, os.path.realpath does not follow the symlink,
+            # therefore the two sides are only equal if link_path == path
             if os.path.realpath(link_path) == os.path.realpath(path):
                 # Symlink is already in place. We may have loaded it from cache.
                 self.dependency.is_symlink = True

--- a/src/wurf/dependency_manager.py
+++ b/src/wurf/dependency_manager.py
@@ -99,13 +99,9 @@ class DependencyManager(object):
             # We do not require the 'resolve' function to be implemented in
             # dependency projects. Therefore the mandatory=False.
             #
-            # @todo the str() here is needed as waf does not handle unicode
-            # in its find_node function (invoked from within recurse). So that
-            # would be nice to fix.
+            # str() is needed as waf does not handle unicode in its find_node
+            # function (invoked from within recurse).
             self.ctx.recurse([str(path)], mandatory=False)
-
-            # We also do not require a resolve.json file
-            self.load_dependencies(path, mandatory=False)
 
     def __skip_dependency(self, dependency):
         """ Checks if we should skip the dependency.

--- a/src/wurf/git_checkout_resolver.py
+++ b/src/wurf/git_checkout_resolver.py
@@ -10,23 +10,19 @@ class GitCheckoutResolver(object):
     Git Commit Resolver functionality. Checks out a specific commit.
     """
 
-    def __init__(self, git, git_resolver, ctx, dependency, cwd,
-        checkout):
+    def __init__(self, git, git_resolver, ctx, dependency, checkout):
         """ Construct an instance.
 
         :param git: A WurfGit instance
         :param url_resolver: A WurfGitResolver instance.
         :param ctx: A Waf Context instance.
         :param dependency: Dependency instance.
-        :param cwd: Current working directory as a string. This is the place
-            where we should create new folders etc.
         :param checkout: The branch, tag, or sha1 as a string.
         """
         self.git = git
         self.git_resolver = git_resolver
         self.ctx = ctx
         self.dependency = dependency
-        self.cwd = cwd
         self.checkout = checkout
 
     def resolve(self):
@@ -45,36 +41,34 @@ class GitCheckoutResolver(object):
         if self.git.current_commit(cwd=path) == self.checkout:
             return path
 
-        # Use the path retuned to create a unique location for this checkout
-        repo_hash = hashlib.sha1(path.encode('utf-8')).hexdigest()[:6]
-
-        # The folder for storing different versions of this repository
-        repo_name = self.checkout + '-' + repo_hash
-        repo_path = os.path.join(self.cwd, repo_name)
+        # Use the parent folder of the path retuned to store different
+        # versions of this repository
+        repo_folder = os.path.dirname(path)
+        checkout_path = os.path.join(repo_folder, self.checkout)
 
         self.ctx.to_log('wurf: GitCheckoutResolver name {} -> {}'.format(
-            self.dependency.name, repo_path))
+            self.dependency.name, checkout_path))
 
         # If the folder for the chosen version does not exist,
-        # then copy the current repo and checkout that version
-        if not os.path.isdir(repo_path):
-            shutil.copytree(src=path, dst=repo_path, symlinks=True)
-            self.git.checkout(branch=self.checkout, cwd=repo_path)
+        # then copy the master and checkout that version
+        if not os.path.isdir(checkout_path):
+            shutil.copytree(src=path, dst=checkout_path, symlinks=True)
+            self.git.checkout(branch=self.checkout, cwd=checkout_path)
         else:
 
-            if not self.git.is_detached_head(cwd=repo_path):
+            if not self.git.is_detached_head(cwd=checkout_path):
                 # If the checkout is a tag or a commit (we will be in detached
                 # HEAD state), then we cannot pull. On the other hand,
                 # the pull operation should be executed to update a branch.
-                self.git.pull(cwd=repo_path)
+                self.git.pull(cwd=checkout_path)
 
         # If the project contains submodules, we also get those
-        self.git.pull_submodules(cwd=repo_path)
+        self.git.pull_submodules(cwd=checkout_path)
 
         # Record the commmit id of the current working copy
-        self.dependency.git_commit = self.git.current_commit(cwd=repo_path)
+        self.dependency.git_commit = self.git.current_commit(cwd=checkout_path)
 
-        return repo_path
+        return checkout_path
 
     def __repr__(self):
         """

--- a/src/wurf/git_resolver.py
+++ b/src/wurf/git_resolver.py
@@ -2,28 +2,26 @@
 # encoding: utf-8
 
 import os
-import hashlib
 
 class GitResolver(object):
     """
     Base Git Resolver functionality. Clones/pulls a git repository.
     """
 
-    def __init__(self, git, ctx, name, cwd, source):
+    def __init__(self, git, ctx, name, parent_folder, source):
         """ Construct a new WurfGitResolver instance.
 
         :param git: A WurfGit instance
         :param url_resolver: A WurfGitUrlResolver instance.
         :param ctx: A Waf Context instance.
-        :param cwd: Current working directory as a string. This is the place
-            where we should create new folders etc.
+        :param parent_folder: A ParentFolder instance.
         :param name: The name of the dependency as a string
         :param source: The URL of the dependency as a string
         """
         self.git = git
         self.ctx = ctx
         self.name = name
-        self.cwd = cwd
+        self.parent_folder = parent_folder
         self.source = source
 
     def resolve(self):
@@ -34,18 +32,25 @@ class GitResolver(object):
         """
         repo_url = self.source
 
-        # Use the first 6 characters of the SHA1 hash of the repository url
-        # to uniquely identify the repository
-        repo_hash = hashlib.sha1(repo_url.encode('utf-8')).hexdigest()[:6]
+        # The parent folder to store different versions of this repository
+        repo_folder = self.parent_folder.parent_folder(self.name, repo_url)
 
-        # The folder for storing different versions of this repository
-        repo_name = 'master-' + repo_hash
-        repo_path = os.path.join(self.cwd, repo_name)
+        # Make sure that the repo_folder exists
+        if not os.path.exists(repo_folder):
+            self.ctx.to_log("wurf: GitResolver new repository "
+                            "folder: {}".format(repo_folder))
+            os.makedirs(repo_folder)
+
+        # The master will be available in the 'master' subfolder
+        master_path = os.path.join(repo_folder, 'master')
+
+        self.ctx.to_log('wurf: GitResolver name {} -> {}'.format(
+            self.name, master_path))
 
         # If the master folder does not exist, do a git clone first
-        if not os.path.isdir(repo_path):
-            self.git.clone(repository=repo_url, directory=repo_name,
-                cwd=self.cwd)
+        if not os.path.isdir(master_path):
+            self.git.clone(repository=repo_url, directory='master',
+                cwd=repo_folder)
         else:
             # We only want to pull if we haven't just cloned. This avoids
             # having to type in the username and password twice when using
@@ -54,17 +59,17 @@ class GitResolver(object):
                 # git pull will fail if the repository is unavailable
                 # This is not a problem if we have already downloaded
                 # the required version for this dependency
-                self.git.pull(cwd=repo_path)
+                self.git.pull(cwd=master_path)
             except Exception as e:
                 self.ctx.to_log('Exception when executing git pull:')
                 self.ctx.to_log(e)
 
-        assert os.path.isdir(repo_path), "We should have a valid path here!"
+        assert os.path.isdir(master_path), "We should have a valid path here!"
 
         # If the project contains submodules we also get those
-        self.git.pull_submodules(cwd=repo_path)
+        self.git.pull_submodules(cwd=master_path)
 
-        return repo_path
+        return master_path
 
     def __repr__(self):
         """

--- a/src/wurf/git_semver_resolver.py
+++ b/src/wurf/git_semver_resolver.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-import hashlib
 import os
 import shutil
 
@@ -14,23 +13,19 @@ class GitSemverResolver(object):
     Read more about Semantic Versioning here: semver.org
     """
 
-    def __init__(self, git, git_resolver, ctx, semver_selector, cwd,
-        dependency):
+    def __init__(self, git, git_resolver, ctx, semver_selector, dependency):
         """ Construct an instance.
 
         :param git: A WurfGit instance
         :param url_resolver: A WurfGitResolver instance.
         :param ctx: A Waf Context instance.
         :param semver_selector: A SemverSelector instance.
-        :param cwd: Current working directory as a string. This is the place
-            where we should create new folders etc.
         :param dependency: The dependency instance.
         """
         self.git = git
         self.git_resolver = git_resolver
         self.ctx = ctx
         self.semver_selector = semver_selector
-        self.cwd = cwd
         self.dependency = dependency
 
     def resolve(self):
@@ -38,7 +33,6 @@ class GitSemverResolver(object):
 
         :return: The path to the resolved dependency as a string.
         """
-
         path = self.git_resolver.resolve()
 
         assert os.path.isdir(path)
@@ -49,33 +43,32 @@ class GitSemverResolver(object):
 
         if not tag:
             raise DependencyError(
-                msg="No major tag found, candiates were {}".format(tags),
+                msg="No tag found for major version {}, candiates "
+                    "were {}".format(self.dependency.major, tags),
                 dependency=self.dependency)
 
-        # Use the path retuned to create a unique location for this checkout
-        repo_hash = hashlib.sha1(path.encode('utf-8')).hexdigest()[:6]
-
-        # The folder for storing different versions of this repository
-        repo_name = tag + '-' + repo_hash
-        repo_path = os.path.join(self.cwd, repo_name)
+        # Use the parent folder of the path retuned to store different
+        # versions of this repository
+        repo_folder = os.path.dirname(path)
+        tag_path = os.path.join(repo_folder, tag)
 
         self.ctx.to_log('wurf: GitSemverResolver name {} -> {}'.format(
-            self.dependency.name, repo_path))
+            self.dependency.name, tag_path))
 
         # If the folder for the chosen tag does not exist,
         # then copy the master and checkout the tag
-        if not os.path.isdir(repo_path):
-            shutil.copytree(src=path, dst=repo_path, symlinks=True)
-            self.git.checkout(branch=tag, cwd=repo_path)
+        if not os.path.isdir(tag_path):
+            shutil.copytree(src=path, dst=tag_path, symlinks=True)
+            self.git.checkout(branch=tag, cwd=tag_path)
 
         # If the project contains submodules, we also get those
-        self.git.pull_submodules(cwd=repo_path)
+        self.git.pull_submodules(cwd=tag_path)
 
         # Record the commmit id of the current working copy
-        self.dependency.git_commit = self.git.current_commit(cwd=repo_path)
+        self.dependency.git_commit = self.git.current_commit(cwd=tag_path)
         self.dependency.git_tag = tag
 
-        return repo_path
+        return tag_path
 
     def __repr__(self):
         """

--- a/src/wurf/options.py
+++ b/src/wurf/options.py
@@ -14,24 +14,22 @@ class Options(object):
         self.known_args = {}
         self.unknown_args = []
 
-        # Using the %default placeholder:
-        #    http://stackoverflow.com/a/1254491/1717320
         self.parser.add_argument('--resolve_path',
             default=default_resolve_path,
             dest='--resolve_path',
-            help='The folder where the bundled dependencies are downloaded.'
-                 '(default: %(default)s)')
+            help="The folder where the resolved dependencies are downloaded. "
+                 "[default: '{}']".format(default_resolve_path))
 
         self.parser.add_argument('--git_protocol',
             dest='--git_protocol',
-            help='Use a specific git protocol to download dependencies.'
-                 'Supported protocols {}'.format(supported_git_protocols))
+            help='Use a specific git protocol to download dependencies. '
+                 'Supported protocols: {}'.format(supported_git_protocols))
 
         self.parser.add_argument('--symlinks_path',
             default=default_symlinks_path,
             dest='--symlinks_path',
-            help='The folder where the dependency symlinks are placed.'
-                 '(default: %(default)s)')
+            help="The folder where the dependency symlinks are placed. "
+                 "[default: '{}']".format(default_symlinks_path))
 
         self.parser.add_argument('--fast_resolve', dest='--fast_resolve',
             action='store_true', default=False,

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -255,14 +255,8 @@ def parser(registry):
     return argparse.ArgumentParser(description='Resolve Options',
         # add_help=False will remove the default handling of --help and -h
         # https://docs.python.org/3/library/argparse.html#add-help
-        #
         # This will be handled by waf's default options context.
-        add_help=False,
-        # Remove printing usage help, like:
-        #    usage: waf [--some-option]
-        # When printing help, this seems to be an undocumented feature of
-        # argparse: http://stackoverflow.com/a/14591302/1717320
-        usage=argparse.SUPPRESS)
+        add_help=False)
 
 
 @Registry.cache

--- a/src/wurf/registry.py
+++ b/src/wurf/registry.py
@@ -196,18 +196,6 @@ def resolve_path(registry):
 
 @Registry.cache
 @Registry.provide
-def dependency_path(registry, dependency):
-    resolve_path = registry.require('resolve_path')
-
-    dependency_path = os.path.join(resolve_path, dependency.name)
-    waf_utils = registry.require('waf_utils')
-    waf_utils.check_dir(dependency_path)
-
-    return dependency_path
-
-
-@Registry.cache
-@Registry.provide
 def symlinks_path(registry):
     mandatory_options = registry.require('mandatory_options')
     symlinks_path = mandatory_options.symlinks_path()
@@ -432,13 +420,13 @@ def git_resolvers(registry, dependency):
     git = registry.require('git')
     ctx = registry.require('ctx')
     options = registry.require('options')
-    dependency_path = registry.require('dependency_path', dependency=dependency)
+    parent_folder = registry.require('parent_folder')
 
     name = dependency.name
     sources = registry.require('git_sources', dependency=dependency)
 
     def wrap(source):
-        return GitResolver(git=git, ctx=ctx, cwd=dependency_path,
+        return GitResolver(git=git, ctx=ctx, parent_folder=parent_folder,
                            name=name, source=source)
 
     resolvers = [wrap(source) for source in sources]
@@ -457,15 +445,13 @@ def git_checkout_list_resolver(registry, dependency, checkout):
     git = registry.require('git')
     ctx = registry.require('ctx')
     options = registry.require('options')
-    dependency_path = registry.require('dependency_path', dependency=dependency)
 
     git_resolvers = registry.require('git_resolvers', dependency=dependency)
 
     def wrap(resolver):
 
         resolver = GitCheckoutResolver(git=git, git_resolver=resolver, ctx=ctx,
-            dependency=dependency, cwd=dependency_path,
-            checkout=checkout)
+            dependency=dependency, checkout=checkout)
 
         resolver = TryResolver(resolver=resolver, ctx=ctx)
         return resolver
@@ -512,15 +498,13 @@ def resolve_git_semver(registry, dependency):
     ctx = registry.require('ctx')
     git_resolvers = registry.require('git_resolvers', dependency=dependency)
     options = registry.require('options')
-    dependency_path = registry.require('dependency_path', dependency=dependency)
 
     # Set the resolver method on the dependency
     dependency.resolver_action = 'git semver'
 
     def wrap(resolver):
         resolver = GitSemverResolver(git=git, git_resolver=resolver, ctx=ctx,
-            semver_selector=semver_selector, cwd=dependency_path,
-            dependency=dependency)
+            semver_selector=semver_selector, dependency=dependency)
 
         resolver = TryResolver(resolver=resolver, ctx=ctx)
         return resolver

--- a/src/wurf/waf_entry_point.py
+++ b/src/wurf/waf_entry_point.py
@@ -44,6 +44,7 @@ from . import waf_resolve_context
 from . import waf_options_context
 from . import waf_configuration_context
 from . import waf_build_context
+from . import waf_standalone_context
 
 # We add a number of methods to the ConfigurationContext and BuildContext
 # objects used in Waf's configure(...) and build(...) functions (found in

--- a/src/wurf/waf_options_context.py
+++ b/src/wurf/waf_options_context.py
@@ -129,28 +129,30 @@ class WafOptionsContext(Options.OptionsContext):
         Here we inject the arguments which were not consumed in the resolve
         step.
         """
-
         # We expect _args to be None here, if it isn't we should probably
         # figure out why and see if we should combine it with the
         # self.waf_options list
         assert(_args is None)
 
         try:
-            super(WafOptionsContext, self).parse_args(_args=self.waf_options)
-
-        except SystemExit:
-
-            # If optparse (which is the options parser use by waf) sees
-            # -h or --help it will call sys.exit(0) to stop the program and
-            # print the help message for the user.
-            #
-            # sys.exit() will raise the SytemExit exception so an easy way for
-            # us to add our help message here is to catch that and print our
-            # help and then re-raise.
-
+            # We may not have a wurf_options instance if running in a folder
+            # without a wscript (see class documentation)
+            # If the instance is present, we copy all the resolve options
+            # from the argparse.ArgumentParser to optparse.OptionParser that
+            # was created by waf. This way, optparse can print out a unified
+            # help text and option errors will be printed as the last line.
             if self.wurf_options:
-                # We may not have a wurf_parser if running in a folder
-                # without a wscript (see class documentation)
-                self.wurf_options.parser.print_help()
+                # Get the underlying optparse instance from OptionsContext
+                waf_parser = self.parser
+                # We will add the resolve options to this target group
+                target_group = waf_parser.add_option_group('Resolve options')
+                # argparse.ArgumentParser groups all optional arguments to
+                # the "_optionals" groups by default
+                source_group = self.wurf_options.parser._optionals
 
-            raise
+                for action in source_group._group_actions:
+                    target_group.add_option(action.option_strings[0],
+                        action='store_true' if action.nargs==0 else 'store',
+                        help=action.help)
+        finally:
+            super(WafOptionsContext, self).parse_args(_args=self.waf_options)

--- a/src/wurf/waf_options_context.py
+++ b/src/wurf/waf_options_context.py
@@ -111,6 +111,9 @@ class WafOptionsContext(Options.OptionsContext):
         # second value retuned by parse_known_args(...)
         self.waf_options = self.wurf_options.unknown_args
 
+        # Load any extra tools that define regular options for waf
+        self.load('wurf.waf_standalone_context')
+
         # Call options() in all dependencies: all options must be defined
         # before running OptionsContext.execute() where parse_args is called
         waf_conf.recurse_dependencies(self)

--- a/src/wurf/waf_resolve_context.py
+++ b/src/wurf/waf_resolve_context.py
@@ -98,13 +98,6 @@ class WafResolveContext(Context.Context):
             # which will trigger loading the dependency.
             super(WafResolveContext, self).execute()
 
-            # As the last step in recurse, try to load the dependencies from the
-            # 'resolve.json' file if it is present next to the wscript.
-            # This is done after calling a possible user-defined
-            # resolve() function, since we always want to allow the user to
-            # run custom code before the actual resolving starts.
-            self.dependency_manager.load_dependencies(self.path.abspath(),
-                mandatory=False)
         except Error as e:
             self.logger.debug("Error in resolve:".format(e), exc_info=True)
             self.fatal("Error: {}".format(e))
@@ -123,6 +116,17 @@ class WafResolveContext(Context.Context):
 
         for action in post_resolver_actions:
             action()
+
+    def post_recurse(self, node):
+        # As the last step in recurse, try to load the dependencies from the
+        # 'resolve.json' file if it is present next to the wscript.
+        # This is done after calling a possible user-defined
+        # resolve() function, since we always want to allow the user to
+        # run custom code before the actual resolving starts.
+        self.dependency_manager.load_dependencies(self.path.abspath(),
+            mandatory=False)
+
+        super(WafResolveContext, self).post_recurse(node)
 
     def is_toplevel(self):
         """

--- a/src/wurf/waf_standalone_context.py
+++ b/src/wurf/waf_standalone_context.py
@@ -1,0 +1,50 @@
+#! /usr/bin/env python
+# encoding: utf-8
+
+from waflib.Scripting import Dist
+from waflib import Options
+
+
+def options(opt):
+
+    opts = opt.add_option_group('Standalone archive options')
+
+    opts.add_option('--standalone_archive', action='store', default=None,
+                    help='Name of the standalone archive')
+
+    opts.add_option('--standalone_algo', action='store', default='zip',
+                    help='Compression algorithm of the standalone archive. '
+                         'Possible values: [zip, tar.bz2, tar.gz]')
+
+    opts.add_option('--standalone_exclude', action='store', default=None,
+                    help='Patterns to exclude files from the standalone '
+                         'archive. (e.g. "*.cache **/*.class")')
+
+
+class WafStandaloneContext(Dist):
+
+    '''creates a standalone archive that contains all dependencies'''
+    cmd = 'standalone'
+
+    def __init__(self, **kw):
+        super(Dist, self).__init__(**kw)
+
+        if Options.options.standalone_archive:
+            self.base_name = Options.options.standalone_archive
+
+        self.algo = Options.options.standalone_algo
+
+    def get_files(self):
+        excludes = Dist.get_excl(self)
+        if Options.options.standalone_exclude:
+            # A whitespace separator is needed as the existing excludes
+            # string might not end with whitespace
+            excludes += ' '
+            excludes += Options.options.standalone_exclude
+        excludes += ' waf-* waf3-* .waf-* .waf3-* .lock-* ' \
+            '*.zip *.tar.bz2 *.tar.gz VSProjects *.vcxproj* *.sln '\
+            '*.sdf *.suo *.bat *.log *.user build resolve_symlinks '\
+            'resolved_dependencies/*/master'
+
+        return self.base_path.ant_glob(
+            '**/*', dir=True, excl=excludes.split())

--- a/test/add_dependency/test_add_dependency.py
+++ b/test/add_dependency/test_add_dependency.py
@@ -202,9 +202,9 @@ def run_commands(app_dir, git_dir):
     app_dir.run('python', 'waf', 'build', '-v')
 
     resolve_dir = app_dir.join('resolved_dependencies')
-    assert resolve_dir.contains_dir('foo','1.3.3.7-*')
-    assert resolve_dir.contains_dir('baz','3.3.1-*')
-    assert resolve_dir.contains_dir('bar','someh4sh-*')
+    assert resolve_dir.contains_dir('foo-*','1.3.3.7')
+    assert resolve_dir.contains_dir('baz-*','3.3.1')
+    assert resolve_dir.contains_dir('bar-*','someh4sh')
 
     resolve_dir.rmdir()
 
@@ -226,18 +226,15 @@ def run_commands(app_dir, git_dir):
     # The content of resolved dependencies is intersting now :)
     # We've just resolved from the lock_resolve.json file
     # containing the versions needed.
-    #
-    # The on some repositories we the commit we are asking for
-    # is the same as on the master and some not.
-    #
+
     # foo should use the commit id in the lock file
-    assert resolve_dir.contains_dir("foo", "{}-*".format(
+    assert resolve_dir.contains_dir("foo-*", "{}".format(
         lock['dependencies']['foo']['checkout']))
     # bar is locked to the same commit as the master so it will
     # skip the git checkout and just return the master path
-    assert resolve_dir.contains_dir('bar', 'master-*')
-    # baz has it's tag in the lock file, so it will be available there
-    assert resolve_dir.contains_dir('baz', '3.3.1-*')
+    assert resolve_dir.contains_dir('bar-*', 'master')
+    # baz has its tag in the lock file, so it will be available there
+    assert resolve_dir.contains_dir('baz-*', '3.3.1')
 
     app_dir.rmfile('lock_resolve.json')
     resolve_dir.rmdir()

--- a/test/add_dependency/test_add_dependency.py
+++ b/test/add_dependency/test_add_dependency.py
@@ -388,5 +388,5 @@ def test_create_standalone_archive(test_directory):
         json.dump(clone_path, json_file)
 
     app_dir.run('python', 'waf', 'configure', '-v', '--lock_paths')
-    app_dir.run('python', 'waf', '-v', 'dist')
-    assert app_dir.contains_file('test_add_dependency-1.0.0.tar.bz2')
+    app_dir.run('python', 'waf', '-v', 'standalone')
+    assert app_dir.contains_file('test_add_dependency-1.0.0.zip')

--- a/test/python/test_git.py
+++ b/test/python/test_git.py
@@ -25,10 +25,10 @@ def test_wurf_git_current_commit():
 
     git = Git('/bin/git_binary', ctx)
 
-    assert git.current_commit(cwd='/tmp') == "044d59505f3b63645c7fb7dec145154b8e518086"
+    assert git.current_commit(cwd='/tmp') == \
+        "044d59505f3b63645c7fb7dec145154b8e518086"
     ctx.cmd_and_log.assert_called_once_with(
         ['/bin/git_binary', 'rev-parse', 'HEAD'], cwd='/tmp')
-
 
 def test_wurf_git_clone():
 

--- a/test/python/test_git_checkout_resolver.py
+++ b/test/python/test_git_checkout_resolver.py
@@ -25,7 +25,7 @@ def test_git_checkout_resolver(test_directory):
     repo_url = 'https://gitlab.com/steinwurf/links.git'
 
     resolver = GitCheckoutResolver(git=git, git_resolver=git_resolver,
-        ctx=ctx, dependency=dependency, cwd=cwd, checkout=checkout)
+        ctx=ctx, dependency=dependency, checkout=checkout)
 
     path = resolver.resolve()
 

--- a/test/python/test_git_resolver.py
+++ b/test/python/test_git_resolver.py
@@ -9,7 +9,8 @@ def test_git_resolver(test_directory):
 
     ctx = mock.Mock()
     git = mock.Mock()
-    cwd = test_directory.path()
+    parent_folder = mock.Mock()
+    parent_folder.parent_folder.return_value = test_directory.path()
 
     # GitResolver checks that the directory is created during git.clone,
     # so we create it within the test_directory as a side effect
@@ -22,16 +23,16 @@ def test_git_resolver(test_directory):
     repo_url = 'https://gitlab.com/steinwurf/links.git'
 
     resolver = GitResolver(git=git, ctx=ctx, name=name,
-        cwd=cwd, source=repo_url)
+        parent_folder=parent_folder, source=repo_url)
 
     path = resolver.resolve()
 
     repo_name = os.path.basename(os.path.normpath(path))
-    assert repo_name.startswith('master-')
+    assert repo_name == 'master'
     repo_folder = os.path.dirname(os.path.normpath(path))
 
     git.clone.assert_called_once_with(
-        repository=repo_url, directory=repo_name, cwd=repo_folder)
+        repository=repo_url, directory='master', cwd=repo_folder)
 
     git.pull_submodules.assert_called_once_with(cwd=path)
 

--- a/test/python/test_git_semver_resolver.py
+++ b/test/python/test_git_semver_resolver.py
@@ -13,8 +13,8 @@ def test_git_semver_resolver(test_directory):
 
     # Create a parent folder for the dependency and the corresponding
     # subfolder for the 'master' checkout
-    repo_folder = test_directory.mkdir('links')
-    master_folder = repo_folder.mkdir('master-01234')
+    repo_folder = test_directory.mkdir('links-01234')
+    master_folder = repo_folder.mkdir('master')
 
     dependency = mock.Mock()
     dependency.name = 'links'
@@ -29,8 +29,7 @@ def test_git_semver_resolver(test_directory):
     semver_selector.select_tag.return_value = selected_tag
 
     resolver = GitSemverResolver(git=git, git_resolver=git_resolver,
-        ctx=ctx, semver_selector=semver_selector,cwd=repo_folder.path(),
-        dependency=dependency)
+        ctx=ctx, semver_selector=semver_selector, dependency=dependency)
 
     path = resolver.resolve()
 


### PR DESCRIPTION
@mortenvp These are meant to be my last steps before release. I fixed the ExistingTagResolver and added a corresponding integration test with GitSemverResolver, so this will not break if the paths are changed for some reason.
I also found a way to integrate the resolve options into the regular waf options. The help text looks a lot more consistent now, and you get an error in the last line of the output if you specified some missing option (this was quite horrible before).
I reintroduced the "standalone" command to produce a decent archive, this is much better than invoking the vanilla "dist".
I am still extremely unhappy with the error output, e.g. when some dependency resolution fails. If I compare this with the previous waf, then it is clear that we have a problem here. I think we can make it more user-friendly with some hard failures.
Take a look when you have time and add some comments ;)